### PR TITLE
Add selenium dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Marcet-Society-Curated-Calendar-of-Events
 Curated Calendar of Events in Major U.S. Cities with Google Calendar Integration
+
+## Setup
+
+Install Python dependencies used by the scraper utilities:
+
+```bash
+pip install -r requirements.txt
+```
+
+The `requirements.txt` file currently lists `selenium` and
+`webdriver-manager` which are required for running the Selenium based
+scripts under `old_unused_files/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+selenium
+webdriver-manager


### PR DESCRIPTION
## Summary
- add requirements.txt listing `selenium` and `webdriver-manager`
- document dependency install instructions in README

## Testing
- `pip3 install -r requirements.txt` *(fails: could not access pypi)*

------
https://chatgpt.com/codex/tasks/task_e_687e71a4d568833286271ccf11a23944