### PR TITLE
Fix loading for csv events

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ pip install -r requirements.txt
 The `requirements.txt` file currently lists `selenium` and
 `webdriver-manager` which are required for running the Selenium based
 scripts under `old_unused_files/`.
+
+When deploying events, the integration scripts look for
+`cultural_events.json` first and fall back to `csv_based_events.json`
+if present.

--- a/auto_deploy_events.py
+++ b/auto_deploy_events.py
@@ -3,13 +3,26 @@ import json
 import os
 from datetime import datetime
 
+EVENT_FILES = ["cultural_events.json", "csv_based_events.json"]
+
+def detect_events_file():
+    """Return the first existing events file or None."""
+    for fname in EVENT_FILES:
+        if os.path.exists(fname):
+            return fname
+    return None
+
 def load_events_from_file():
-    """Load events handling both old and new JSON formats"""
+    """Load events from whichever JSON file is available."""
+    events_file = detect_events_file()
+    if not events_file:
+        print("❌ No events file found.")
+        return []
+
     try:
-        with open('cultural_events.json', 'r', encoding='utf-8') as f:
+        with open(events_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
-        print(f"🔍 File loaded successfully. Type: {type(data)}")
+        print(f"🔍 Loaded {events_file}. Type: {type(data)}")
         
         # Handle both old format (array) and new format (object with events)
         if isinstance(data, list):
@@ -33,15 +46,18 @@ def load_events_from_file():
 
 def create_react_integration_script():
     """Create the React integration script"""
-    react_integration_code = '''import json
+    events_file = detect_events_file() or "cultural_events.json"
+    react_integration_code = f'''import json
 import re
 import os
 from datetime import datetime
 
+EVENTS_FILE = "{events_file}"
+
 def load_events_from_file():
     """Load events handling both old and new JSON formats"""
     try:
-        with open('cultural_events.json', 'r', encoding='utf-8') as f:
+        with open(EVENTS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
         
         # Handle both old format (array) and new format (object with events)
@@ -162,16 +178,17 @@ def auto_deploy_scraped_events():
     print("🔄 Starting automatic deployment of scraped events...")
     print("=" * 60)
     
-    # Check if we have scraped events
-    if not os.path.exists('cultural_events.json'):
-        print("❌ No cultural_events.json found.")
+    # Determine which events file to use
+    events_file = detect_events_file()
+    if not events_file:
+        print("❌ No events JSON file found.")
         return False
     
     # Load events with proper format handling
     events = load_events_from_file()
-    
+
     if not events:
-        print("❌ No events found in cultural_events.json")
+        print(f"❌ No events found in {events_file}")
         return False
     
     print(f"📊 Found {len(events)} events to deploy")

--- a/react_integration.py
+++ b/react_integration.py
@@ -3,12 +3,26 @@ import re
 import os
 from datetime import datetime
 
+EVENT_FILES = ["cultural_events.json", "csv_based_events.json"]
+
+def detect_events_file():
+    """Return the first existing events file or None."""
+    for fname in EVENT_FILES:
+        if os.path.exists(fname):
+            return fname
+    return None
+
 def main():
     print("🔄 Starting React Integration...")
     
-    # Step 1: Load events from JSON file
+    # Step 1: Determine which JSON file to use
+    events_file = detect_events_file()
+    if not events_file:
+        print("❌ No events JSON file found")
+        return False
+
     try:
-        with open('cultural_events.json', 'r', encoding='utf-8') as f:
+        with open(events_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
         
         # Handle both formats
@@ -20,7 +34,7 @@ def main():
             print("❌ Could not find events in the JSON file")
             return False
             
-        print(f"✅ Loaded {len(events)} events from JSON file")
+        print(f"✅ Loaded {len(events)} events from {events_file}")
         
     except Exception as e:
         print(f"❌ Error loading events: {e}")

--- a/react_integration_safe.py
+++ b/react_integration_safe.py
@@ -3,12 +3,25 @@ import re
 import os
 from datetime import datetime
 
+EVENT_FILES = ["cultural_events.json", "csv_based_events.json"]
+
+def detect_events_file():
+    for fname in EVENT_FILES:
+        if os.path.exists(fname):
+            return fname
+    return None
+
 def main():
     print("🔄 Starting SAFE React Integration...")
     
     # Load events
+    events_file = detect_events_file()
+    if not events_file:
+        print("❌ No events JSON file found")
+        return False
+
     try:
-        with open('cultural_events.json', 'r', encoding='utf-8') as f:
+        with open(events_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
         
         if isinstance(data, dict) and 'events' in data:
@@ -16,7 +29,7 @@ def main():
         else:
             events = data
             
-        print(f"✅ Loaded {len(events)} events")
+        print(f"✅ Loaded {len(events)} events from {events_file}")
         
     except Exception as e:
         print(f"❌ Error loading events: {e}")

--- a/safe_event_integration.py
+++ b/safe_event_integration.py
@@ -1,11 +1,25 @@
 import json
 import re
+import os
+
+EVENT_FILES = ["cultural_events.json", "csv_based_events.json"]
+
+def detect_events_file():
+    for fname in EVENT_FILES:
+        if os.path.exists(fname):
+            return fname
+    return None
 
 def main():
     print("🔧 SAFE Event Integration (Syntax-Error-Free)...")
     
     # Load events
-    with open('cultural_events.json') as f:
+    events_file = detect_events_file()
+    if not events_file:
+        print("❌ No events JSON file found")
+        return False
+
+    with open(events_file, 'r', encoding='utf-8') as f:
         data = json.load(f)
     events = data['events'] if isinstance(data, dict) else data
     print(f"✅ Loaded {len(events)} events")


### PR DESCRIPTION
## Summary
- allow integration scripts to fall back to `csv_based_events.json`
- document fallback behavior in the README

## Testing
- `python -m py_compile auto_deploy_events.py react_integration.py react_integration_safe.py safe_event_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe41d60188332a506ef4c6f9600d8