### PR TITLE
Update event types and theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,16 +15,16 @@ body {
 }
 
 /* Utility classes - Rose theme */
-.bg-rose-50 { background-color: #fff1f2; }
-.bg-rose-100 { background-color: #ffe4e6; }
-.bg-rose-400 { background-color: #fb7185; }
-.bg-rose-500 { background-color: #f43f5e; }
-.text-rose-600 { color: #e11d48; }
-.text-rose-700 { color: #be123c; }
-.text-rose-800 { color: #9f1239; }
-.border-rose-200 { border-color: #fecdd3; }
-.border-rose-300 { border-color: #fda4af; }
-.border-rose-400 { border-color: #fb7185; }
+.bg-indigo-50 { background-color: #eef2ff; }
+.bg-indigo-100 { background-color: #e0e7ff; }
+.bg-indigo-400 { background-color: #818cf8; }
+.bg-indigo-500 { background-color: #6366f1; }
+.text-indigo-600 { color: #4f46e5; }
+.text-indigo-700 { color: #4338ca; }
+.text-indigo-800 { color: #3730a3; }
+.border-indigo-200 { border-color: #c7d2fe; }
+.border-indigo-300 { border-color: #a5b4fc; }
+.border-indigo-400 { border-color: #818cf8; }
 
 /* Stone colors */
 .bg-stone-50 { background-color: #fafaf9; }
@@ -159,8 +159,8 @@ body {
 .hover\:bg-stone-50:hover { background-color: #fafaf9; }
 .hover\:bg-stone-100:hover { background-color: #f5f5f4; }
 .hover\:bg-stone-200:hover { background-color: #e7e5e4; }
-.hover\:bg-rose-500:hover { background-color: #f43f5e; }
-.hover\:border-rose-300:hover { border-color: #fda4af; }
+.hover\:bg-indigo-500:hover { background-color: #6366f1; }
+.hover\:border-indigo-300:hover { border-color: #a5b4fc; }
 .hover\:border-stone-300:hover { border-color: #d6d3d1; }
 .hover\:text-stone-700:hover { color: #44403c; }
 .hover\:shadow-md:hover { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
@@ -168,8 +168,8 @@ body {
 
 /* Focus states */
 .focus\:outline-none:focus { outline: 2px solid transparent; outline-offset: 2px; }
-.focus\:ring-2:focus { box-shadow: 0 0 0 2px #fda4af; }
-.focus\:border-rose-400:focus { border-color: #fb7185; }
+.focus\:ring-2:focus { box-shadow: 0 0 0 2px #a5b4fc; }
+.focus\:border-indigo-400:focus { border-color: #818cf8; }
 
 /* Background gradient */
 .bg-gradient-to-br {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -87,7 +87,7 @@ const App = () => {
       museum: "poetry_society",
       date: "2025-07-27",
       time: "7:30 PM",
-      type: "readings",
+      type: "performances",
       description: "Contemporary poetry with local and visiting authors.",
       city: "New York",
       price: "$15",
@@ -100,7 +100,7 @@ const App = () => {
       museum: "albertine",
       date: "2025-07-28",
       time: "6:00 PM",
-      type: "workshops",
+      type: "special_event",
       description: "Interactive workshop exploring French literary traditions.",
       city: "New York",
       price: "$25",
@@ -126,7 +126,7 @@ const App = () => {
       museum: "womens_history",
       date: "2025-07-30",
       time: "7:00 PM",
-      type: "lectures",
+      type: "lecture",
       description: "Celebrating contributions of women throughout history.",
       city: "New York",
       price: "Free",
@@ -144,10 +144,12 @@ const App = () => {
   const eventTypes = [
     { id: "all", label: "All Events", icon: Calendar },
     { id: "exhibitions", label: "Exhibitions", icon: Palette },
-    { id: "talks", label: "Talks & Lectures", icon: Users },
-    { id: "readings", label: "Readings", icon: BookOpen },
-    { id: "workshops", label: "Workshops", icon: Music },
-    { id: "lectures", label: "Lectures", icon: Users }
+    { id: "special_event", label: "Special Event", icon: Users },
+    { id: "lecture", label: "Lecture", icon: BookOpen },
+    { id: "tour", label: "Tour", icon: Calendar },
+    { id: "performances", label: "Performances", icon: Music },
+    { id: "panel_discussion", label: "Panel Discussion", icon: Users },
+    { id: "talks", label: "Talks", icon: BookOpen }
   ];
 
   // Cities for filtering
@@ -321,8 +323,8 @@ const App = () => {
                 onClick={() => setSelectedCity(city)}
                 className={`px-4 py-2 rounded-full text-sm font-medium transition-all border-2 ${
                   selectedCity === city
-                    ? "bg-rose-400 text-white shadow-md border-rose-400"
-                    : "bg-white text-stone-600 hover:bg-stone-50 border-rose-200 hover:border-rose-300"
+                    ? "bg-indigo-400 text-white shadow-md border-indigo-400"
+                    : "bg-white text-stone-600 hover:bg-stone-50 border-indigo-200 hover:border-indigo-300"
                 }`}
               >
                 {city}
@@ -344,7 +346,7 @@ const App = () => {
                   placeholder="Search events..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 border border-stone-300 rounded-lg focus:ring-2 focus:ring-rose-200 focus:border-rose-400"
+                  className="w-full pl-10 pr-4 py-3 border border-stone-300 rounded-lg focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400"
                 />
               </div>
             </div>
@@ -360,7 +362,7 @@ const App = () => {
                       onClick={() => setFilterType(type.id)}
                       className={`flex items-center gap-2 px-4 py-2 rounded-full transition-colors ${
                         filterType === type.id
-                          ? "bg-rose-500 text-white"
+                          ? "bg-indigo-500 text-white"
                           : "bg-white text-stone-700 border border-stone-300 hover:bg-stone-50"
                       }`}
                     >
@@ -386,7 +388,7 @@ const App = () => {
                         [categoryName]: e.target.value,
                       }));
                     }}
-                    className="w-full px-3 py-2 text-sm border border-stone-300 rounded-md focus:ring-2 focus:ring-rose-200 focus:border-rose-400 bg-white"
+                    className="w-full px-3 py-2 text-sm border border-stone-300 rounded-md focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400 bg-white"
                   >
                     <option value="all">{categoryData.icon} All {categoryName}</option>
                     {categoryData.institutions.map((inst) => (
@@ -407,20 +409,21 @@ const App = () => {
                   disabled={!isGoogleLoaded}
                   className={`px-4 py-2 rounded-md font-medium transition-colors ${
                     isGoogleLoaded
-                      ? "bg-rose-500 text-white hover:bg-rose-600"
+                      ? "bg-indigo-500 text-white hover:bg-indigo-600"
                       : "bg-gray-300 text-gray-500 cursor-not-allowed"
                   }`}
                 >
                   {isGoogleLoaded ? "Connect Google Calendar" : "Loading..."}
                 </button>
               ) : (
-                <div className="inline-flex items-center px-3 py-2 bg-rose-50 text-rose-700 rounded-md border border-rose-200">
+                <div className="inline-flex items-center px-3 py-2 bg-indigo-50 text-indigo-700 rounded-md border border-indigo-200">
                   <Calendar className="w-4 h-4 mr-2" />Connected
                 </div>
               )}
             </div>
           </aside>
           <section className="lg:col-span-3">
+            <h2 className="text-2xl font-serif text-stone-800 mb-4">Cultural Events in {selectedCity}</h2>
             <div className="space-y-6">
               {filteredEvents.map((event) => (
                 <div key={event.id} className="bg-white rounded-md shadow p-6">
@@ -436,14 +439,17 @@ const App = () => {
                   <p className="text-sm text-stone-700 mt-2 whitespace-pre-line">
                     {event.description}
                   </p>
-                  <a
-                    href={event.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-blue-700 underline mt-2 inline-block"
-                  >
-                    Event Link
-                  </a>
+                  <div className="flex items-center gap-2 mt-2">
+                    <a
+                      href={event.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-blue-700 underline"
+                    >
+                      Learn More
+                    </a>
+                    <button className="text-indigo-600 text-lg leading-none">+</button>
+                  </div>
                 </div>
               ))}
 


### PR DESCRIPTION
## Summary
- refresh color scheme to indigo tones
- expand event type filters and sample data
- show selected city heading on event list
- add simple `Learn More` link and plus button on each card

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c7e78e6c83329f1bbf7461e28b7e