### PR TITLE
Fix hidden selected city button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -19,6 +19,8 @@ body {
 .bg-indigo-100 { background-color: #e0e7ff; }
 .bg-indigo-400 { background-color: #818cf8; }
 .bg-indigo-500 { background-color: #6366f1; }
+.bg-indigo-700 { background-color: #4338ca; }
+.bg-indigo-800 { background-color: #3730a3; }
 .text-indigo-600 { color: #4f46e5; }
 .text-indigo-700 { color: #4338ca; }
 .text-indigo-800 { color: #3730a3; }


### PR DESCRIPTION
## Summary
- define missing `.bg-indigo-700` and `.bg-indigo-800` classes

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688109039b588332adf697be681fa926